### PR TITLE
walltime-to-time_min Generalization for All Clusters - 12.9.24 - Rakshya

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -172,7 +172,8 @@ if zipped:
         conda: 'envs/p7z.yaml'
         threads: 4
         resources:
-            mem_mb = 4000,
+            #mem_mb = 4000,
+            mem_mb = 16000,
             time_min = 5
         shell:
             r'''
@@ -217,7 +218,8 @@ rule stats:
     conda: "envs/r_stats.yaml"
     threads: 22
     resources:
-        mem_mb = 4000,
+        #mem_mb = 4000,
+        mem_mb = 88000,
         #walltime = '8:00'
         time_min = 480
     script: "scripts/Post_imputation.Rmd"
@@ -303,7 +305,8 @@ if sampfilt and minimac_version in ['guess', '3']:
             sf = sampfilt
         threads: 8
         resources:
-            mem_mb = 256,
+            #mem_mb = 256,
+            mem_mb = 2048,
             #walltime = '24:00'
             time_min = 1440
         conda: "envs/bcftools.yaml"
@@ -337,7 +340,8 @@ elif minimac_version in ['guess', '3']:
             filt = qualfilt
         threads: 8
         resources:
-            mem_mb = 256,
+            #mem_mb = 256,
+            mem_mb = 2048,
            # walltime = '24:00'
             time_min = 1440
         conda: "envs/bcftools.yaml"
@@ -370,7 +374,8 @@ elif sampfilt:
             sf = sampfilt
         threads: 8
         resources:
-            mem_mb = 256,
+            #mem_mb = 256,
+            mem_mb = 2048,
             #walltime = '24:00'
             time_min = 1440
         conda: "envs/bcftools.yaml"
@@ -392,7 +397,8 @@ else:
             filt = qualfilt
         threads: 8
         resources:
-            mem_mb = 256,
+            #mem_mb = 256,
+            mem_mb = 2048,
             #walltime = '24:00'
             time_min = 1440
         conda: "envs/bcftools.yaml"
@@ -437,7 +443,8 @@ rule rename:
     conda: "envs/bcftools.yaml"
     threads: 2
     resources:
-        mem_mb = 1024,
+        #mem_mb = 1024,
+        mem_mb = 2048,
         time_min = 60
     shell:
         '''
@@ -468,7 +475,8 @@ rule renameAuto:
     conda: "envs/bcftools.yaml"
     threads: 2
     resources:
-        mem_mb = 1024,
+        #mem_mb = 1024,
+        mem_mb = 2048,
         time_min = 60
     shell:
         '''
@@ -481,7 +489,8 @@ rule concat_chroms_samp:
     output: "{impute_dir}/data/{cohort}_chrall_filtered.vcf.gz"
     threads: 8
     resources:
-        mem_mb = 512,
+        #mem_mb = 512,
+        mem_mb = 4096,
         #walltime = '24:00'
         time_min = 1440
     conda: "envs/bcftools.yaml"
@@ -504,7 +513,8 @@ rule merge_samples_chrom:
     output: "{impute_dir}/data/by_chrom/all_chr{chrom}_filtered.vcf.gz"
     threads: 8
     resources:
-        mem_mb = 2000,
+        #mem_mb = 2000,
+        mem_mb = 16000,
         #walltime = "36:00"
         time_min = 2160
     conda: "envs/bcftools.yaml"
@@ -515,7 +525,8 @@ rule concat_chroms_all:
     output: "{impute_dir}/data/all_chrall_filtered.vcf.gz"
     threads: 8
     resources:
-        mem_mb = 256,
+        #mem_mb = 256,
+        mem_mb = 2048,
         #walltime = "24:00"
         time_min = 1440
     conda: "envs/bcftools.yaml"
@@ -529,7 +540,8 @@ rule make_plink_all:
         ID = "--id-delim" if automap_tf else "--double-id"
     threads: 10
     resources:
-        mem_mb = 3000,
+        #mem_mb = 3000,
+        mem_mb = 30000,
         #walltime = "96:00"
         time_min = 5760
     conda: "envs/plink.yaml"
@@ -545,7 +557,8 @@ rule make_plink_samp:
         ID = "--id-delim" if automap_tf else "--double-id "
     threads: 10
     resources:
-        mem_mb = 1000,
+        #mem_mb = 1000,
+        mem_mb = 10000,
         #walltime = "2:00"
         time_min = 120
     conda: "envs/plink.yaml"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -218,7 +218,8 @@ rule stats:
     threads: 22
     resources:
         mem_mb = 4000,
-        walltime = '8:00'
+        #walltime = '8:00'
+        time_min = 480
     script: "scripts/Post_imputation.Rmd"
 
 # Sample filtering rules
@@ -244,7 +245,8 @@ rule fixheaders:
     threads: 1
     resources:
         mem_mb = 2048,
-        walltime = '24:00'
+        #walltime = '24:00'
+        time_min = 1440
     conda: "envs/bcftools.yaml"
     shell:
         r"""
@@ -270,7 +272,8 @@ if minimac_version == 'guess':
         threads: 1
         resources:
             mem_mb = 2048,
-            walltime = '24:00'
+            #walltime = '24:00'
+            time_min = 1440
         script: 'scripts/rule_detect_minimac.py'
 else:
     rule detect_minimac:
@@ -282,7 +285,8 @@ else:
         localrule: True
         resources:
             mem_mb = 2048,
-            walltime = '1:00'
+            #walltime = '1:00'
+            time_min = 60
         shell: 'echo {params.ver} > {output}'
 
 
@@ -300,7 +304,8 @@ if sampfilt and minimac_version in ['guess', '3']:
         threads: 8
         resources:
             mem_mb = 256,
-            walltime = '24:00'
+            #walltime = '24:00'
+            time_min = 1440
         conda: "envs/bcftools.yaml"
         shell:
             r'''
@@ -333,7 +338,8 @@ elif minimac_version in ['guess', '3']:
         threads: 8
         resources:
             mem_mb = 256,
-            walltime = '24:00'
+           # walltime = '24:00'
+            time_min = 1440
         conda: "envs/bcftools.yaml"
         shell:
             r'''
@@ -365,7 +371,8 @@ elif sampfilt:
         threads: 8
         resources:
             mem_mb = 256,
-            walltime = '24:00'
+            #walltime = '24:00'
+            time_min = 1440
         conda: "envs/bcftools.yaml"
         shell:
             r'''
@@ -386,7 +393,8 @@ else:
         threads: 8
         resources:
             mem_mb = 256,
-            walltime = '24:00'
+            #walltime = '24:00'
+            time_min = 1440
         conda: "envs/bcftools.yaml"
         shell:
             r'''
@@ -474,7 +482,8 @@ rule concat_chroms_samp:
     threads: 8
     resources:
         mem_mb = 512,
-        walltime = '24:00'
+        #walltime = '24:00'
+        time_min = 1440
     conda: "envs/bcftools.yaml"
     shell: "bcftools concat -o {output} -Oz --threads 8 {input}"
 
@@ -496,7 +505,8 @@ rule merge_samples_chrom:
     threads: 8
     resources:
         mem_mb = 2000,
-        walltime = "36:00"
+        #walltime = "36:00"
+        time_min = 2160
     conda: "envs/bcftools.yaml"
     shell: "bcftools merge -m none -o {output} -Oz --threads 8 {input.vcf}"
 
@@ -506,7 +516,8 @@ rule concat_chroms_all:
     threads: 8
     resources:
         mem_mb = 256,
-        walltime = "24:00"
+        #walltime = "24:00"
+        time_min = 1440
     conda: "envs/bcftools.yaml"
     shell: "bcftools concat -o {output} -Oz --threads 8 {input}"
 
@@ -519,7 +530,8 @@ rule make_plink_all:
     threads: 10
     resources:
         mem_mb = 3000,
-        walltime = "96:00"
+        #walltime = "96:00"
+        time_min = 5760
     conda: "envs/plink.yaml"
     shell:
         "plink --keep-allele-order --vcf {input} {params.ID} --memory 10000 --threads 10 --make-bed "
@@ -534,7 +546,8 @@ rule make_plink_samp:
     threads: 10
     resources:
         mem_mb = 1000,
-        walltime = "2:00"
+        #walltime = "2:00"
+        time_min = 120
     conda: "envs/plink.yaml"
     shell:
         "plink --keep-allele-order --vcf {input} {params.ID} --memory 10000 --threads 10 --make-bed "


### PR DESCRIPTION
## Overview

This pull request generalizes the conversion of the `walltime` parameter to `time_min`. The change aims to standardize time management by using total minutes instead of the `HH:MM` format, as discussed with Brian in the habshd meeting.

## Changes Made

- **Parameter Renaming:**
  - Renamed `walltime` to `time_min` in Snakefile.
  
- **Value Conversion:**
  - Updated all `walltime` values from `HH:MM` or `HH:MM:SS` formats to total minutes.
    - Example: `'24:00'` → `1440`, `'96:00'` → `5760`, `'140:00'` → `8400`

## Rationale

Using `time_min` simplifies time calculations and ensures consistency across different cluster configurations.
## Related Discussions

- Discussed in the habshd meeting on [11.25.24]
  